### PR TITLE
chore: prepare to release openresty v1.27.1.1

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -31,6 +31,9 @@ elif [[ "$1" == *openresty-1.21.4.* ]]; then
 elif [[ "$1" == *openresty-1.25.3.* ]]; then
     patch="$PWD/nginx-1.25.3.patch"
     dir="$1/bundle/nginx-1.25.3"
+elif [[ "$1" == *openresty-1.27.1.* ]]; then
+    patch="$PWD/nginx-1.27.1.patch"
+    dir="$1/bundle/nginx-1.27.1"
 else
     err "can't detect OpenResty version"
     exit 1


### PR DESCRIPTION
CI passing in APISIX repo: https://github.com/apache/apisix/pull/11936/commits/7eca3d668718eaa3db995b91c077f3d5712128e9