### PR TITLE
fix: error implicit truncation

### DIFF
--- a/ngx_multi_upstream_module.h
+++ b/ngx_multi_upstream_module.h
@@ -28,7 +28,7 @@ typedef struct {
 
     void                *data_c;
 
-    ngx_flag_t           connected:1;
+    ngx_flag_t           connected;
 
     void                *cur;
 } ngx_multi_connection_t;


### PR DESCRIPTION
fix: https://github.com/api7/apisix-nginx-module/actions/runs/14489685082/job/40643039964?pr=102

Neither Clang nor GCC can bypass this error, so it needs to be fixed or the build will fail.

By examining other use cases for ngx_flag_t in the nginx code, I found that it is not usually set to use only 1bit and it is not unsigned by default, so it fails to compile.
So here the :1 is removed, it may waste some memory but should not have side effects. Another more radical fix would be to change its definition to unsigned int, which would require multiple changes, and since the module is copied from upstream, I don't think this is feasible.

BTW, I'm doubtful that the module should still be in apisix-runtime, which is serving the dubbo-proxy plugin.